### PR TITLE
Move all optional parameters specified after required parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ $fields =  [
 $relations = [
 ];
 
-$zaiusClient->createObjectSchema('test_objects', 'Test Object', 'test_object', $fields, $relations);
+$zaiusClient->createObjectSchema('test_objects', 'Test Object', $fields, $relations, 'test_object');
         
 ```
 

--- a/src/ZaiusClient.php
+++ b/src/ZaiusClient.php
@@ -240,7 +240,7 @@ class ZaiusClient
      * @return mixed
      * @throws ZaiusException
      */
-    public function createObjectSchema($name,$displayName,$alias='',$fields,$relations,$queue=false) {
+    public function createObjectSchema($name,$displayName,$fields,$relations,$alias='',$queue=false) {
         $this->apiKey = $this->privateKey;
         $data = [];
         $data['name'] = $name;

--- a/tests/Rest/ObjectsTest.php
+++ b/tests/Rest/ObjectsTest.php
@@ -55,7 +55,7 @@ class ObjectsTest extends TestAbstract {
         ];
 
         try {
-            $zaiusClient->createObjectSchema('test_objects', 'Test Object', 'test_object', $fields, $relations);
+            $zaiusClient->createObjectSchema('test_objects', 'Test Object', $fields, $relations, 'test_object');
         }
         catch (ZaiusException $exception) {
             if(!strpos($exception->getMessage(),'already used by another object')) {


### PR DESCRIPTION
Move the optional alias parameter after any other mandatory parameters so this will not throw an exception in php8.1 (https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.optional-before-required)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/zaius-php-sdk/10)
<!-- Reviewable:end -->
